### PR TITLE
Класс Object переименован в BaseObject для поддержки php7.2

### DIFF
--- a/src/AbstractList.php
+++ b/src/AbstractList.php
@@ -15,7 +15,7 @@ use GuzzleHttp\Exception\RequestException;
  *
  * @property $getParams GET параметры запроса.
  */
-abstract class AbstractList extends Object implements \Iterator
+abstract class AbstractList extends BaseObject implements \Iterator
 {
     /**
      * Кол-во потоков.

--- a/src/BaseObject.php
+++ b/src/BaseObject.php
@@ -9,7 +9,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Базовый класс.
  */
-class Object
+class BaseObject
 {
     /**
      * Наименование лога.

--- a/src/Parser/Json.php
+++ b/src/Parser/Json.php
@@ -2,13 +2,13 @@
 
 namespace SimaLand\API\Parser;
 
-use SimaLand\API\Object;
+use SimaLand\API\BaseObject;
 use SimaLand\API\Record;
 
 /**
  * Сохранение данных в json файл.
  */
-class Json extends Object implements StorageInterface
+class Json extends BaseObject implements StorageInterface
 {
     /**
      * Пулный путь до файла.

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -3,7 +3,7 @@
 namespace SimaLand\API\Parser;
 
 use SimaLand\API\AbstractList;
-use SimaLand\API\Object;
+use SimaLand\API\BaseObject;
 use SimaLand\API\Record;
 
 /**
@@ -26,7 +26,7 @@ use SimaLand\API\Record;
  *
  * ```
  */
-class Parser extends Object
+class Parser extends BaseObject
 {
     /**
      * Кол-во итераций после которых сохраняются мета данные.

--- a/src/Record.php
+++ b/src/Record.php
@@ -5,7 +5,7 @@ namespace SimaLand\API;
 /**
  * Запись сущности.
  */
-class Record extends Object
+class Record extends BaseObject
 {
     /**
      * Данные одной строки.

--- a/src/Rest/Client.php
+++ b/src/Rest/Client.php
@@ -5,14 +5,14 @@ namespace SimaLand\API\Rest;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Psr7\Response;
-use SimaLand\API\Object;
+use SimaLand\API\BaseObject;
 
 /**
  * SimaLand клиент.
  *
  * @link https://www.sima-land.ru/api/v3/help/
  */
-class Client extends Object
+class Client extends BaseObject
 {
     /**
      * Базовый url API sima-land.ru.

--- a/src/Rest/Request.php
+++ b/src/Rest/Request.php
@@ -2,12 +2,12 @@
 
 namespace SimaLand\API\Rest;
 
-use SimaLand\API\Object;
+use SimaLand\API\BaseObject;
 
 /**
  * Класс запроса к API simaland.
  */
-class Request extends Object
+class Request extends BaseObject
 {
     /**
      * Наименование сущности.

--- a/tests/BaseCase.php
+++ b/tests/BaseCase.php
@@ -7,7 +7,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use SimaLand\API\Object;
+use SimaLand\API\BaseObject;
 use SimaLand\API\Rest\Client;
 
 class BaseCase extends \PHPUnit_Framework_TestCase
@@ -23,7 +23,7 @@ class BaseCase extends \PHPUnit_Framework_TestCase
      */
     public function getLogger()
     {
-        $logger = new Logger(Object::LOGGER_NAME);
+        $logger = new Logger(BaseObject::LOGGER_NAME);
         $logger->pushHandler(new NullHandler());
         return $logger;
     }

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -4,22 +4,22 @@ namespace SimaLand\API\Tests;
 
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use SimaLand\API\Object;
+use SimaLand\API\BaseObject;
 use SimaLand\API\Tests\models\TestModel;
 
 class ObjectTest extends BaseCase
 {
     public function testGetSetLogger()
     {
-        $object = new Object();
+        $object = new BaseObject();
         $this->assertInstanceOf('\Psr\Log\LoggerInterface', $object->getLogger());
 
-        $logger = new Logger(Object::LOGGER_NAME);
+        $logger = new Logger(BaseObject::LOGGER_NAME);
         $logger->pushHandler(new NullHandler());
-        $object = new Object(['logger' => $logger]);
+        $object = new BaseObject(['logger' => $logger]);
         $this->assertInstanceOf('\Psr\Log\LoggerInterface', $object->getLogger());
 
-        $object = new Object();
+        $object = new BaseObject();
         $object->setLogger($logger);
         $this->assertInstanceOf('\Psr\Log\LoggerInterface', $object->getLogger());
     }

--- a/tests/models/TestModel.php
+++ b/tests/models/TestModel.php
@@ -2,7 +2,7 @@
 
 namespace SimaLand\API\Tests\models;
 
-use SimaLand\API\Object;
+use SimaLand\API\BaseObject;
 
 /**
  * Class TestModel
@@ -11,7 +11,7 @@ use SimaLand\API\Object;
  * @property $sid int
  * @property $name string
  */
-class TestModel extends Object
+class TestModel extends BaseObject
 {
     protected $sid;
 


### PR DESCRIPTION
Протестировано на
PHP 7.2.5-1+ubuntu18.04.1+deb.sury.org+1 (cli) (built: May  5 2018 05:00:15) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
    with Zend OPcache v7.2.5-1+ubuntu18.04.1+deb.sury.org+1, Copyright (c) 1999-2018, by Zend Technologies
    with Xdebug v2.6.0, Copyright (c) 2002-2018, by Derick Rethans
